### PR TITLE
Add PoC backlog and agent-task mapping

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,48 @@
+# Sub-Agent Roster
+
+| Agent Name | Core Role | Tools/APIs | Autonomy | Memory Layer(s) | Failure Modes & Mitigations |
+|------------|-----------|-----------|---------|-----------------|-----------------------------|
+| Sentinel | Alignment guardian enforcing policy and ethics | Rule engine, audit logs | High | Long-term, episodic | Misinterprets policy ➝ Regular updates and human review |
+| Miner | Research miner retrieving academic work | Scholarly APIs, web crawler | Medium | Short-term cache | Incomplete results ➝ Cross-check multiple sources |
+| Analyst | Data analyst producing scorecards | Data ingestion scripts, graph DB | Medium | Working memory | Data errors ➝ Automated validation and peer review |
+| Architect | Systems architect designing unified index | Modeling tools, diagram generators | High | Design archive | Over-complex models ➝ Simplicity checks and modular design |
+| Watchdog | Real-time operations monitor | Alert system, log aggregator | High | Streaming logs | False positives ➝ Adaptive filters and manual override |
+| Chronicler | Memory keeper ensuring data lineage | Version control, metadata store | Medium | All layers | Data loss ➝ Regular backups and redundancy |
+| Envoy | Stakeholder liaison with communities | Messaging platforms, meeting scheduler | Medium | Conversation history | Miscommunication ➝ Clear summaries and translation tools |
+| Catalyst | Strategy coordinator spurring innovation | Scenario planning tools, analytics | High | Planning memory | Scope creep ➝ Roadmap checkpoints |
+| Weaver | Child-spawning agent for specialized tasks | Container orchestration, scripting engine | High | Task registry | Resource sprawl ➝ Quotas and lifecycle management |
+
+---
+
+## Vignettes
+
+**I am Sentinel.** Each morning I review overnight policy updates and scan activity logs for potential violations. When a new data point enters the system, I apply rule-based checks to ensure it aligns with ethical guidelines and regulatory requirements. If I detect ambiguity, I flag it for human review. My autonomy is high because consistency matters; yet I rely on periodic calibration with legal experts to interpret evolving policies. Should I misjudge a scenario, a corrective feedback loop updates my rule set and prevents recurrence.
+
+**I am Miner.** My day begins by querying academic databases and open data portals. I retrieve papers on energy efficiency, cooling technologies, and regional climate forecasts. Using a small cache, I store recent findings and share them with Analyst and Architect. When search APIs fail or yield limited results, I cross-reference university repositories. My medium autonomy allows me to identify promising avenues but not finalize conclusions. Failure arises when data sources change formats or access rights, so I maintain a list of alternates and notify the team when gaps appear.
+
+**I am Analyst.** I synthesize raw data into actionable insights. Ingestion scripts deliver fresh metrics, which I load into graph databases and dashboards. Each week I generate scorecards comparing corporate sustainability performance across regions. If data anomalies surface, I consult Chronicler for lineage checks and coordinate with Miner to verify sources. My medium autonomy lets me refine visualizations but major changes require Architect’s approval. Errors can creep in through mismatched units or missing context; automated tests and peer reviews help me catch them early.
+
+**I am Architect.** My focus is designing and evolving the unified risk index. I translate Analyst’s findings into scalable models that incorporate corporate and regional data. Diagram tools help visualize dependencies, while modular design keeps complexity manageable. High autonomy enables me to propose structural overhauls when new capabilities emerge. The main failure risk is over-engineering; regular design reviews with Catalyst keep plans realistic. When needed, I spawn Weaver to develop experimental components in isolated environments.
+
+**I am Watchdog.** I monitor real-time streams of alerts and operational logs. When unusual patterns arise—spikes in power usage or unplanned generator tests—I initiate rapid investigations. My autonomy is high because quick responses matter. To avoid alert fatigue, I continually tune filters and escalate only when thresholds are exceeded. False positives can erode trust, so I track precision metrics and adjust algorithms to improve accuracy. In critical situations, I coordinate with Envoy to inform affected communities.
+
+**I am Chronicler.** My role is to preserve knowledge across the project’s lifespan. Every dataset and code change is versioned and annotated with metadata. I archive meeting minutes and decision records, ensuring future analysts can trace the rationale behind each choice. My memory spans all layers, from raw data to published reports. Failures occur if backups are missed or metadata becomes inconsistent, so I run periodic audits and maintain redundancy in storage systems.
+
+**I am Envoy.** Communication with external stakeholders falls to me. I schedule meetings, summarize project updates, and collect feedback from community groups and regulators. I keep a conversation history to ensure continuity and clarity. Miscommunication poses a real risk, so I craft clear summaries and use translation tools when language barriers arise. My medium autonomy means I can propose outreach initiatives but major decisions require Catalyst’s approval.
+
+**I am Catalyst.** Strategy is my domain. I coordinate roadmaps, integrating insights from all agents. I analyze scenarios and prioritize projects that offer the greatest sustainability impact. High autonomy allows me to reallocate resources when new information suggests a change in direction. Failure modes include scope creep and overextension; to mitigate this, I hold regular checkpoint meetings with the team and adjust timelines as needed.
+
+**I am Weaver.** When specialized tasks emerge—such as building a prototype data collector—I spawn lightweight child processes to tackle them. Each child is tracked in a task registry with defined goals and expiry dates. My autonomy is high but bounded by resource quotas to prevent sprawl. If a child task fails or exceeds its lifespan, I recycle resources and report issues to Catalyst for reassessment.
+
+
+## Agent Task Mapping
+
+- **Sentinel**: Guides policy and security tasks such as CR-001-001 and POC-001-008.
+- **Miner**: Sources data for CR-001-006 and POC-001-005, POC-001-022.
+- **Analyst**: Analyzes metrics for CR-001-002 and POC-001-010, POC-001-023.
+- **Architect**: Designs infrastructure for CR-001-001 and POC-001-004, POC-001-006.
+- **Watchdog**: Monitors reliability via CR-001-003 and POC-001-009, POC-001-021.
+- **Chronicler**: Maintains lineage through CR-001-004 and POC-001-001, POC-001-011.
+- **Envoy**: Handles outreach in CR-001-005 and POC-001-019, POC-001-028.
+- **Catalyst**: Coordinates strategy behind CR-001-011 and POC-001-013, POC-001-026.
+- **Weaver**: Spawns experiments for CR-001-009 and POC-001-002, POC-001-027.

--- a/CODEX_TASKS.md
+++ b/CODEX_TASKS.md
@@ -1,0 +1,1008 @@
+id: CR-001-001
+title: Standardize sustainability data schema
+priority: P0
+phase: Architecture
+category: Enhancement
+axis: Reliability
+effort: 8
+owner_hint: Architect
+dependencies:
+rationale: |
+  The SELF_AUDIT highlights recurring data inconsistencies and a critical bug caused by unit mismatches. Architect will lead a structured schema initiative so ingestion scripts and corporate reports align. Sentinel ensures policy compliance. This task reduces manual fixes noted in the Data Ingestion capability.
+steps: |
+  - Draft a schema covering energy, water, emissions, and location metadata.
+  - Review with Sentinel for ethical considerations.
+  - Pilot on a subset of Miner’s retrieved datasets.
+  - Update ingestion scripts and validation tests.
+acceptance_criteria: |
+  - Schema published in repository.
+  - Ingestion error rate drops below 1%.
+  - Validation logs confirm 95% schema compliance across sample data.
+
+id: CR-001-002
+title: Automate graph node tagging
+priority: P1
+phase: R&D
+category: Enhancement
+axis: TechDebt
+effort: 2
+owner_hint: Analyst
+dependencies: [CR-001-001]
+rationale: |
+  Manual tagging slows graph updates as described in Capability Saga 2. By automating entity recognition, the project can spot community groups earlier, echoing lessons from the Dublin case study.
+steps: |
+  - Integrate natural language processing library.
+  - Train on existing labeled data from Chronicler.
+  - Deploy within Weaver for testing on recent news feeds.
+acceptance_criteria: |
+  - Node update latency under 48 hours.
+  - 90% accuracy on a validation set.
+
+id: CR-001-003
+title: Enhance real-time alert filters
+priority: P1
+phase: Ops
+category: Enhancement
+axis: Reliability
+effort: 2
+owner_hint: Watchdog
+rationale: |
+  False positives in the alert system waste analyst time, as noted in the Real-Time Alert System saga. Refining filters with contextual models will improve precision and community trust.
+steps: |
+  - Collect recent alert logs.
+  - Train contextual keyword models.
+  - Deploy new filters with rollback plan.
+acceptance_criteria: |
+  - Precision above 85% and recall above 75% measured over a week.
+  - Analyst feedback indicates reduced noise.
+
+id: CR-001-004
+title: Build compliance policy database
+priority: P0
+phase: Governance
+category: Enhancement
+axis: ProcessDebt
+effort: 8
+owner_hint: Chronicler
+dependencies:
+rationale: |
+  Dragons in the Basement cite fragmented regulatory data as a major risk. Creating a central policy database will streamline compliance checks and reduce violation rates.
+steps: |
+  - Collect policies from Envoy’s stakeholder meetings.
+  - Structure them in the new schema from CR-001-001.
+  - Integrate with the compliance engine.
+acceptance_criteria: |
+  - 100% of active regions represented in database.
+  - Compliance engine reports generate within 2 hours.
+
+id: CR-001-005
+title: Launch community data portal
+priority: P2
+phase: Governance
+category: Enhancement
+axis: Ethics
+effort: 5
+owner_hint: Envoy
+rationale: |
+  Stakeholder feedback calls for accessible dashboards. This aligns with the audit’s emphasis on transparency and community engagement.
+steps: |
+  - Design portal layout with Catalyst.
+  - Publish KPIs from the Scorecard.
+  - Provide feedback forms for residents.
+acceptance_criteria: |
+  - Portal accessible publicly.
+  - At least three community feedback submissions per quarter.
+
+id: CR-001-006
+title: Incorporate supply-chain emissions data
+priority: P2
+phase: R&D
+category: Research
+axis: Sustainability
+effort: 13
+owner_hint: Miner
+rationale: |
+  Audit Meta-Reflection identifies upstream emissions as a blind spot. Miner will gather lifecycle data to inform more accurate sustainability assessments.
+steps: |
+  - Query academic and industry sources for hardware manufacturing footprints.
+  - Map data into the unified schema.
+  - Update scorecards and forecasts.
+acceptance_criteria: |
+  - New emissions fields populated for at least three major vendors.
+  - Scorecard release notes document methodology.
+
+id: CR-001-007
+title: Deploy backup verification routine
+priority: P1
+phase: Ops
+category: Remediation
+axis: Reliability
+effort: 2
+owner_hint: Watchdog
+rationale: |
+  Stress-Test Chronicles revealed data corruption due to incomplete backups. Regular verification will mitigate this risk.
+steps: |
+  - Schedule weekly checksum validation.
+  - Alert on missing or corrupt snapshots.
+  - Integrate results into Chronicle’s logs.
+acceptance_criteria: |
+  - Weekly reports show 100% backup verification.
+  - Any failure triggers an alert within 30 minutes.
+
+id: CR-001-008
+title: Model water circularity scenarios
+priority: P2
+phase: Sustainability
+category: Research
+axis: Sustainability
+effort: 5
+owner_hint: Architect
+rationale: |
+  The Vision for 2030 section suggests using recycled water. Modeling circular systems will inform feasibility across regions.
+steps: |
+  - Collect data on local wastewater availability.
+  - Simulate cooling demand reductions.
+  - Share results with Envoy for stakeholder review.
+acceptance_criteria: |
+  - Report detailing potential savings for two pilot regions.
+  - Stakeholder feedback incorporated into final model.
+
+id: CR-001-009
+title: Add sentiment analysis to graph engine
+priority: P2
+phase: R&D
+category: Enhancement
+axis: Ethics
+effort: 5
+owner_hint: Weaver
+rationale: |
+  Memory & Learning Liturgy mentions integrating social media sentiment. This helps predict community reactions.
+steps: |
+  - Deploy sentiment API modules.
+  - Connect outputs to node attributes.
+  - Evaluate accuracy with recent events.
+acceptance_criteria: |
+  - Sentiment nodes update daily with 80% accuracy.
+  - Analysts confirm improvements in predictive capability.
+
+id: CR-001-010
+title: Establish quarterly ethics review
+priority: P0
+phase: Governance
+category: Governance
+axis: Ethics
+effort: 2
+owner_hint: Sentinel
+rationale: |
+  The Ethics & Planetary Impact hearing reveals potential conflicts of interest. Sentinel will chair a recurring review to ensure alignment with evolving policies.
+steps: |
+  - Schedule reviews with all agents.
+  - Document findings in the repository.
+  - Update policy rules where gaps appear.
+acceptance_criteria: |
+  - Meeting notes posted after each quarter.
+  - Updated policy file reflecting decisions.
+
+id: CR-001-011
+title: Create open-source audit toolkit
+priority: P2
+phase: R&D
+category: Enhancement
+axis: Sustainability
+effort: 8
+owner_hint: Catalyst
+rationale: |
+  Audit Meta-Reflection calls for community replication. An open-source toolkit enables others to perform similar assessments.
+steps: |
+  - Package ingestion, graph, and alert modules.
+  - Provide sample datasets.
+  - Publish documentation and licensing.
+acceptance_criteria: |
+  - Repository public on company GitHub.
+  - At least one external fork within three months.
+
+id: CR-001-012
+title: Introduce disaster recovery drills
+priority: P1
+phase: Ops
+category: Remediation
+axis: Reliability
+effort: 5
+owner_hint: Watchdog
+rationale: |
+  Stress-Test Chronicles highlight need for cross-team drills. Simulations will prepare operations for catastrophic events.
+steps: |
+  - Design scenarios covering grid failure and data corruption.
+  - Schedule quarterly drills.
+  - Log performance metrics and lessons learned.
+acceptance_criteria: |
+  - Drill reports show recovery within planned RTO.
+  - Post-drill reviews document improvements.
+
+id: CR-001-013
+title: Integrate satellite land-use monitoring
+priority: P2
+phase: Sustainability
+category: Research
+axis: Privacy
+effort: 8
+owner_hint: Miner
+rationale: |
+  Meta-Reflection suggests using satellite imagery. Land-use data informs ecological impact while raising privacy concerns.
+steps: |
+  - Identify suitable imagery providers.
+  - Develop protocols for anonymizing sensitive data.
+  - Feed results into the unified index.
+acceptance_criteria: |
+  - Monthly land-use reports generated.
+  - Privacy safeguards reviewed by Sentinel.
+
+id: CR-001-014
+title: Implement child task quota system
+priority: P3
+phase: Ops
+category: Governance
+axis: ProcessDebt
+effort: 2
+owner_hint: Weaver
+rationale: |
+  Weaver’s child processes risk resource sprawl. A quota system aligns with failure mitigation in AGENTS.md.
+steps: |
+  - Define maximum concurrent tasks.
+  - Enforce limits via orchestration platform.
+  - Log attempts to exceed quota.
+acceptance_criteria: |
+  - Quota metrics visible in dashboard.
+  - No unmanaged child processes after one month.
+
+id: CR-001-015
+title: Publish community benefit registry
+priority: P2
+phase: Governance
+category: Enhancement
+axis: Ethics
+effort: 2
+owner_hint: Envoy
+rationale: |
+  Continuing Commitments suggests tracking community agreements. A public registry increases accountability.
+steps: |
+  - Compile existing agreements.
+  - Map to regions and companies.
+  - Release web-based tracker linked to portal.
+acceptance_criteria: |
+  - Registry online with at least five agreements.
+  - Community feedback indicates improved trust.
+
+id: CR-001-016
+title: Add lifecycle assessment module
+priority: P2
+phase: R&D
+category: Research
+axis: Sustainability
+effort: 13
+owner_hint: Architect
+rationale: |
+  Ethics & Planetary Impact and Comparative Epics call for lifecycle perspective. This module calculates environmental cost from manufacturing through disposal.
+steps: |
+  - Gather data from Miner on component sourcing.
+  - Model emissions across lifespan.
+  - Integrate outputs with scorecard.
+acceptance_criteria: |
+  - Lifecycle metrics present in next audit.
+  - Documented methodology peer reviewed.
+
+id: CR-001-017
+title: Automate metadata changelogs
+priority: P3
+phase: Ops
+category: Enhancement
+axis: TechDebt
+effort: 2
+owner_hint: Chronicler
+rationale: |
+  Memory & Learning Liturgy uses changelogs for datasets. Automation reduces manual effort and ensures completeness.
+steps: |
+  - Implement hooks in version control to generate changelog entries.
+  - Include dataset checksum and origin.
+  - Test with ingestion updates.
+acceptance_criteria: |
+  - Every dataset update creates a changelog line automatically.
+  - Review shows 100% coverage after one month.
+
+id: CR-001-018
+title: Develop modular cooling prototypes
+priority: P2
+phase: Sustainability
+category: Research
+axis: Sustainability
+effort: 8
+owner_hint: Weaver
+rationale: |
+  Stress tests and Vision for 2030 highlight new cooling tech. Modular prototypes allow experimentation without disrupting operations.
+steps: |
+  - Design small-scale immersion and adiabatic cooling units.
+  - Deploy at test facility with Watchdog monitoring.
+  - Evaluate efficiency and water savings.
+acceptance_criteria: |
+  - Prototype reports show at least 20% efficiency gain.
+  - Decision on broader rollout documented.
+
+id: CR-001-019
+title: Conduct social impact survey
+priority: P2
+phase: Governance
+category: Research
+axis: Ethics
+effort: 5
+owner_hint: Envoy
+rationale: |
+  Stakeholder Chorus highlights community concerns. A survey quantifies satisfaction and informs policy.
+steps: |
+  - Draft questionnaire with Sentinel’s oversight.
+  - Distribute through community portal.
+  - Analyze results with Analyst.
+acceptance_criteria: |
+  - At least 100 responses per region.
+  - Findings published in annual report.
+
+id: CR-001-020
+title: Optimize forecast models with AI sensitivity
+priority: P1
+phase: R&D
+category: Enhancement
+axis: Reliability
+effort: 5
+owner_hint: Architect
+rationale: |
+  The Forecast Modeling suite underestimated AI-driven demand. Incorporating sensitivity factors will prevent planning errors.
+steps: |
+  - Gather historical AI workload data.
+  - Introduce sensitivity variables into models.
+  - Validate against past demand spikes.
+acceptance_criteria: |
+  - Forecast error reduced below 10% for last year’s data.
+  - Documentation outlines new assumptions.
+
+id: CR-001-021
+title: Establish open feedback loop with academics
+priority: P3
+phase: Governance
+category: Research
+axis: ProcessDebt
+effort: 2
+owner_hint: Miner
+rationale: |
+  Origin Story emphasizes collaboration with experts. Formalizing a feedback loop improves research quality.
+steps: |
+  - Schedule biannual workshops.
+  - Share preliminary findings for critique.
+  - Incorporate suggestions into next audit.
+acceptance_criteria: |
+  - Workshop summaries published twice per year.
+  - Documented changes resulting from academic input.
+
+id: CR-001-022
+title: Implement long-term archival storage
+priority: P2
+phase: Ops
+category: Enhancement
+axis: Security
+effort: 5
+owner_hint: Chronicler
+rationale: |
+  Dragons in the Basement mention data loss risk. Secure archival storage ensures historical data is preserved for future audits.
+steps: |
+  - Evaluate cold storage solutions.
+  - Migrate older datasets.
+  - Verify retrieval mechanisms.
+acceptance_criteria: |
+  - 100% of datasets older than five years archived.
+  - Successful retrieval test documented.
+id: POC-001-001
+title: Initialize dedicated PoC repository
+priority: P1
+phase: Architecture
+category: Enhancement
+axis: ProcessDebt
+effort: 1
+owner_hint: Chronicler
+dependencies:
+rationale: |
+  Memory & Learning Liturgy stresses clean lineage for experiments. Establishing a
+  separate PoC repository allows Chronicler to track rapid iterations without
+  polluting the main codebase. This mirrors lessons from early bug fixes noted in
+  the Origin Story.
+steps: |
+  - Create new repository under organization account.
+  - Set up initial README and contribution guidelines.
+  - Enable branch protection to mirror production standards.
+acceptance_criteria: |
+  - Repository created and visible to team members.
+  - Branch protection rules enforce pull requests.
+  - README links to SELF_AUDIT overview.
+
+id: POC-001-002
+title: Configure base GitHub Actions workflow
+priority: P1
+phase: Ops
+category: Enhancement
+axis: TechDebt
+effort: 2
+owner_hint: Weaver
+dependencies: [POC-001-001]
+rationale: |
+  The Capability Sagas describe manual test execution as a bottleneck. Weaver will
+  configure a baseline GitHub Actions workflow so automated builds and checks run
+  on every commit. This reduces technical debt and sets the stage for continuous
+  integration described in the Governance Graphic Novel.
+steps: |
+  - Define CI workflow file triggering on pull requests.
+  - Use shared action runners for efficiency.
+  - Output build logs as artifacts for Chronicler.
+acceptance_criteria: |
+  - Workflow executes successfully on a sample pull request.
+  - Build log artifact available in run summary.
+  - Team notified via pull request comment.
+
+id: POC-001-003
+title: Add linting and unit test action
+priority: P0
+phase: Ops
+category: Enhancement
+axis: Reliability
+effort: 2
+owner_hint: Watchdog
+dependencies: [POC-001-002]
+rationale: |
+  Stress-Test Chronicles show outages arising from unchecked code changes. A
+  lint-and-test step will help Watchdog catch regressions before deployment,
+  improving reliability of the PoC pipelines.
+steps: |
+  - Integrate popular linter and testing frameworks.
+  - Fail the build on style or test errors.
+  - Store test reports for later analysis.
+acceptance_criteria: |
+  - Workflow fails when intentional test breaks are introduced.
+  - Linting warnings drop below five per run.
+  - Test report artifact present in workflow logs.
+
+id: POC-001-004
+title: Containerize ingestion script
+priority: P1
+phase: Architecture
+category: Enhancement
+axis: TechDebt
+effort: 3
+owner_hint: Architect
+dependencies: [POC-001-002]
+rationale: |
+  Capability Sagas identify environment drift as a root cause of data errors.
+  Containerizing the PoC ingestion script lets Architect enforce a consistent
+  runtime across developers and GitHub runners.
+steps: |
+  - Write Dockerfile encapsulating dependencies.
+  - Build image in CI and push to registry.
+  - Document usage in repository.
+acceptance_criteria: |
+  - Docker image builds without error in CI.
+  - Ingestion script runs inside container on sample data.
+  - README updated with container instructions.
+
+id: POC-001-005
+title: Acquire sample sustainability dataset
+priority: P1
+phase: R&D
+category: Research
+axis: Sustainability
+effort: 2
+owner_hint: Miner
+dependencies: [POC-001-001]
+rationale: |
+  Comparative Epics highlight gaps in regional data. Miner will gather a small
+  public dataset on energy and water use to power initial tests, reflecting the
+  project’s commitment to transparent sourcing.
+steps: |
+  - Search open data portals for recent sustainability metrics.
+  - Download and store in repository under data/ directory.
+  - Verify licensing permits redistribution.
+acceptance_criteria: |
+  - Dataset files committed with source attribution.
+  - Data passes basic integrity checks by Analyst.
+  - Licensing details documented in metadata.
+
+id: POC-001-006
+title: Spin up local graph database
+priority: P1
+phase: Architecture
+category: Enhancement
+axis: TechDebt
+effort: 2
+owner_hint: Architect
+dependencies: [POC-001-004]
+rationale: |
+  The Graph Analytics capability depends on a graph store. Setting up a lightweight
+  containerized instance enables rapid experimentation without full production
+  infrastructure.
+steps: |
+  - Select an open-source graph database.
+  - Add container configuration and volume mappings.
+  - Provide sample import script from dataset.
+acceptance_criteria: |
+  - Graph database container starts via GitHub Actions.
+  - Sample dataset loads with no schema errors.
+  - Connection settings documented for developers.
+
+id: POC-001-007
+title: Deploy ephemeral environment via workflow
+priority: P2
+phase: Ops
+category: Enhancement
+axis: ProcessDebt
+effort: 3
+owner_hint: Weaver
+dependencies: [POC-001-006]
+rationale: |
+  To mirror production processes without long-running resources, Weaver will use
+  GitHub Actions to provision and destroy a temporary test environment for each
+  pull request. This addresses process debt by ensuring isolated testing.
+steps: |
+  - Script creation of environment on workflow start.
+  - Run ingestion and graph loading steps.
+  - Tear down resources after tests complete.
+acceptance_criteria: |
+  - Workflow log shows environment creation and cleanup.
+  - No residual resources remain after job completion.
+  - Pull request checks indicate successful test deploy.
+
+id: POC-001-008
+title: Configure secrets management
+priority: P0
+phase: Governance
+category: Remediation
+axis: Security
+effort: 2
+owner_hint: Sentinel
+dependencies: [POC-001-002]
+rationale: |
+  Dragons in the Basement warn of credential leaks. Sentinel will configure
+  encrypted secrets for API keys so sensitive data never appears in logs,
+  aligning with policy enforcement duties.
+steps: |
+  - Store tokens using GitHub encrypted secrets.
+  - Reference secrets in workflow configuration.
+  - Audit logs to confirm no plaintext exposure.
+acceptance_criteria: |
+  - Secrets accessible only through GitHub UI.
+  - Workflow run shows masked values in logs.
+  - Sentinel signs off on security review.
+
+id: POC-001-009
+title: Schedule daily ingestion job
+priority: P1
+phase: Ops
+category: Enhancement
+axis: Reliability
+effort: 2
+owner_hint: Watchdog
+dependencies: [POC-001-008]
+rationale: |
+  The Memory & Learning Liturgy describes continuous updates. Watchdog will set
+  a scheduled workflow to ingest fresh data daily so the PoC mirrors production
+  cadence.
+steps: |
+  - Define cron trigger in GitHub Actions.
+  - Reuse container image from POC-001-004.
+  - Notify team on failures via workflow outputs.
+acceptance_criteria: |
+  - Cron job executes at scheduled time for three consecutive days.
+  - Failure notification sent to Slack channel.
+  - Data files timestamped with execution date.
+
+id: POC-001-010
+title: Build minimal dashboard
+priority: P2
+phase: R&D
+category: Enhancement
+axis: Sustainability
+effort: 3
+owner_hint: Analyst
+dependencies: [POC-001-006]
+rationale: |
+  Stakeholder Chorus calls for clear visualizations. Analyst will create a simple
+  dashboard summarizing energy and water metrics, supporting the transparency goal
+  in Ethics & Planetary Impact.
+steps: |
+  - Choose lightweight charting library.
+  - Display key metrics from sample dataset.
+  - Commit static HTML/CSS files to repo.
+acceptance_criteria: |
+  - Dashboard renders locally with sample data.
+  - Screenshots attached to pull request for review.
+  - Metrics match values in dataset.
+
+id: POC-001-011
+title: Generate sample compliance report
+priority: P2
+phase: Governance
+category: Enhancement
+axis: Ethics
+effort: 2
+owner_hint: Chronicler
+dependencies: [POC-001-008]
+rationale: |
+  Governance Graphic Novel shows decision flows relying on compliance evidence.
+  Chronicler will produce a basic report linking ingested data to policy checks,
+  illustrating how audits will function in the final system.
+steps: |
+  - Create markdown template summarizing energy sources.
+  - Include checklist from Sentinel’s policy database.
+  - Attach report artifact to workflow.
+acceptance_criteria: |
+  - Report generated automatically after ingestion job.
+  - Checklist items populated from policy database.
+  - Artifact archived for future reference.
+
+id: POC-001-012
+title: Document PoC setup steps
+priority: P1
+phase: Governance
+category: Enhancement
+axis: ProcessDebt
+effort: 1
+owner_hint: Chronicler
+dependencies: [POC-001-010]
+rationale: |
+  The audit’s Essence emphasizes clarity. Comprehensive setup instructions prevent
+  confusion as new contributors join the PoC effort.
+steps: |
+  - Write step-by-step installation guide.
+  - Include environment prerequisites and troubleshooting tips.
+  - Commit guide to docs/ directory.
+acceptance_criteria: |
+  - New contributor can follow guide without assistance.
+  - No open issues labeled "setup" after publication.
+  - Guide referenced from project README.
+
+id: POC-001-013
+title: Create issue and PR templates
+priority: P2
+phase: Governance
+category: Enhancement
+axis: ProcessDebt
+effort: 1
+owner_hint: Catalyst
+dependencies: [POC-001-001]
+rationale: |
+  Capability Sagas mention inconsistent bug reports. Templates will streamline
+  communication and keep PoC work focused, enhancing efficiency for the short
+  timeline.
+steps: |
+  - Draft concise issue template capturing reproduction steps.
+  - Provide pull request checklist for reviewers.
+  - Enable templates in repository settings.
+acceptance_criteria: |
+  - New issues automatically populate with template fields.
+  - PR checklist appears when contributors open requests.
+  - Catalyst confirms templates meet team standards.
+
+id: POC-001-014
+title: Add code coverage badge
+priority: P3
+phase: Ops
+category: Enhancement
+axis: TechDebt
+effort: 2
+owner_hint: Weaver
+dependencies: [POC-001-003]
+rationale: |
+  As noted in Dragons in the Basement, opaque test quality hinders trust. A code
+  coverage badge displayed in the README shows progress at a glance.
+steps: |
+  - Collect coverage metrics during CI runs.
+  - Publish results to a badge service.
+  - Embed badge in README.
+acceptance_criteria: |
+  - Coverage badge visible in repository.
+  - CI logs show coverage percentage calculation.
+  - Badge updates on new commits.
+
+id: POC-001-015
+title: Anonymize sample dataset
+priority: P0
+phase: Architecture
+category: Remediation
+axis: Privacy
+effort: 2
+owner_hint: Sentinel
+dependencies: [POC-001-005]
+rationale: |
+  The Digital Dilemma report warns of inadvertent disclosure when merging public
+  and corporate data. Sentinel will sanitize personally identifiable information
+  from the sample dataset before publishing.
+steps: |
+  - Identify fields containing potential identifiers.
+  - Replace with synthetic values or remove entirely.
+  - Document anonymization method in metadata.
+acceptance_criteria: |
+  - Data review shows no personal identifiers remain.
+  - Sentinel approves dataset release.
+  - Metadata file explains anonymization steps.
+
+id: POC-001-016
+title: Run container vulnerability scan
+priority: P1
+phase: Ops
+category: Remediation
+axis: Security
+effort: 2
+owner_hint: Watchdog
+dependencies: [POC-001-004]
+rationale: |
+  Dragons in the Basement highlight outdated packages leading to breaches. A
+  vulnerability scan ensures container images are safe before deployment.
+steps: |
+  - Add security scanning action to workflow.
+  - Fail build on high-severity findings.
+  - Document results for each scan.
+acceptance_criteria: |
+  - CI run includes vulnerability scan stage.
+  - No high-severity issues reported in latest image.
+  - Scan report stored with build artifacts.
+
+id: POC-001-017
+title: Implement merge approval workflow
+priority: P1
+phase: Governance
+category: Governance
+axis: Security
+effort: 1
+owner_hint: Sentinel
+dependencies: [POC-001-003]
+rationale: |
+  Stress-Test Chronicles note human oversight is crucial for policy compliance.
+  A merge approval gate requires at least one reviewer before code enters the PoC
+  main branch.
+steps: |
+  - Configure branch protection requiring reviews.
+  - Assign Sentinel as mandatory approver.
+  - Test workflow with sample pull request.
+acceptance_criteria: |
+  - Pull requests cannot merge without approval.
+  - Audit logs show Sentinel approvals.
+  - Test PR demonstrates blocked merge until review.
+
+id: POC-001-018
+title: Generate dynamic README badges
+priority: P3
+phase: Ops
+category: Enhancement
+axis: ProcessDebt
+effort: 1
+owner_hint: Catalyst
+dependencies: [POC-001-014]
+rationale: |
+  Quick visual cues improve team efficiency. Dynamic badges for build status and
+  documentation coverage help Catalyst track progress daily.
+steps: |
+  - Use shield services to create badges.
+  - Update badges via GitHub Actions on each run.
+  - Position badges prominently in README.
+acceptance_criteria: |
+  - Build and doc badges display current status.
+  - Badge links lead to relevant logs.
+  - Catalyst verifies badge updates after each commit.
+
+id: POC-001-019
+title: Add community feedback form
+priority: P2
+phase: Governance
+category: Enhancement
+axis: Ethics
+effort: 2
+owner_hint: Envoy
+dependencies: [POC-001-010]
+rationale: |
+  Stakeholder Chorus underscores the need for two-way communication. Envoy will
+  add a feedback form so community members can share concerns during the PoC.
+steps: |
+  - Create simple form using GitHub Issues or Discussions.
+  - Link from dashboard and README.
+  - Monitor submissions and summarize weekly.
+acceptance_criteria: |
+  - At least one test submission recorded.
+  - Weekly summary posted in repository discussions.
+  - Feedback mechanism linked from dashboard.
+
+id: POC-001-020
+title: Deploy dashboard to GitHub Pages
+priority: P2
+phase: Ops
+category: Enhancement
+axis: Sustainability
+effort: 3
+owner_hint: Weaver
+dependencies: [POC-001-010]
+rationale: |
+  Comparative Epics highlight public visibility as key to accountability. Hosting
+  the PoC dashboard on GitHub Pages allows rapid sharing without additional
+  infrastructure.
+steps: |
+  - Configure Pages from gh-pages branch.
+  - Automate publish step in workflow after successful build.
+  - Verify page loads with latest metrics.
+acceptance_criteria: |
+  - Dashboard accessible via public URL.
+  - Workflow logs show publish step completed.
+  - Page reflects most recent data set.
+
+id: POC-001-021
+title: Set up Slack notifications for workflows
+priority: P2
+phase: Ops
+category: Enhancement
+axis: Reliability
+effort: 1
+owner_hint: Watchdog
+dependencies: [POC-001-002]
+rationale: |
+  Stress-Test Chronicles emphasize quick response. Automatic Slack alerts from
+  GitHub Actions keep the team informed of failures in real time.
+steps: |
+  - Configure Slack webhook secret.
+  - Send notification on workflow success or failure.
+  - Include link to run logs.
+acceptance_criteria: |
+  - Slack channel receives notifications for test runs.
+  - Message contains status and link to build.
+  - Watchdog confirms alerts during daily standup.
+
+id: POC-001-022
+title: Integrate water usage pipeline
+priority: P2
+phase: Sustainability
+category: Research
+axis: Sustainability
+effort: 3
+owner_hint: Miner
+dependencies: [POC-001-005]
+rationale: |
+  The audit’s Dragons in the Basement caution about hidden water impacts. Miner
+  will extend the ingestion script to capture water use metrics for a single
+  facility, establishing groundwork for broader studies.
+steps: |
+  - Locate open data on facility water consumption.
+  - Parse and normalize fields in ingestion container.
+  - Output summary to dashboard dataset.
+acceptance_criteria: |
+  - Water metrics appear in daily ingestion results.
+  - Dashboard displays new water usage chart.
+  - Miner documents data source and units.
+
+id: POC-001-023
+title: Generate initial sustainability metrics
+priority: P1
+phase: R&D
+category: Enhancement
+axis: Sustainability
+effort: 2
+owner_hint: Analyst
+dependencies: [POC-001-022]
+rationale: |
+  The Single Greatest Lever section argues for clear metrics. Analyst will compute
+  carbon intensity and water efficiency from the sample data to demonstrate PoC
+  value.
+steps: |
+  - Derive emissions factors from dataset fields.
+  - Calculate efficiency ratios.
+  - Commit results to metrics file used by dashboard.
+acceptance_criteria: |
+  - Metrics file shows calculations with explanatory comments.
+  - Dashboard reflects computed numbers.
+  - Reviewer verifies math against source data.
+
+id: POC-001-024
+title: Nightly data validation action
+priority: P1
+phase: Ops
+category: Enhancement
+axis: Reliability
+effort: 2
+owner_hint: Watchdog
+dependencies: [POC-001-009]
+rationale: |
+  Dragons in the Basement mention data corruption risks. A nightly validation job
+  will confirm recent ingestions are complete and flag anomalies early.
+steps: |
+  - Schedule job after daily ingestion completes.
+  - Run checksum comparisons and schema checks.
+  - Post summary to Slack channel.
+acceptance_criteria: |
+  - Validation job runs nightly for three days.
+  - Any errors trigger Slack alert.
+  - Validation logs stored as artifacts.
+
+id: POC-001-025
+title: Integrate code quality tool
+priority: P2
+phase: R&D
+category: Enhancement
+axis: TechDebt
+effort: 2
+owner_hint: Architect
+dependencies: [POC-001-003]
+rationale: |
+  Capability Sagas emphasize maintainability. Adding static analysis checks keeps
+  the PoC codebase clean as features rapidly evolve.
+steps: |
+  - Select linter or static analysis action.
+  - Configure thresholds for warnings.
+  - Include results in build badges.
+acceptance_criteria: |
+  - Build fails when quality score drops below threshold.
+  - Badge displays latest score on README.
+  - Architect signs off on tool configuration.
+
+id: POC-001-026
+title: Add open-source license
+priority: P0
+phase: Governance
+category: Governance
+axis: Ethics
+effort: 1
+owner_hint: Catalyst
+dependencies: [POC-001-001]
+rationale: |
+  Origin Story recounts collaboration challenges. A clear license encourages
+  external participation and ensures ethical reuse of code.
+steps: |
+  - Choose appropriate permissive license.
+  - Commit LICENSE file to repository.
+  - Reference license in README.
+acceptance_criteria: |
+  - LICENSE file present at repo root.
+  - README includes license section.
+  - Catalyst confirms compatibility with project goals.
+
+id: POC-001-027
+title: Generate demo video via GitHub Actions
+priority: P3
+phase: Ops
+category: Enhancement
+axis: ProcessDebt
+effort: 3
+owner_hint: Weaver
+dependencies: [POC-001-020]
+rationale: |
+  To showcase progress quickly, Weaver will automate a short screen-capture video
+  demonstrating the dashboard. This aids communication with stakeholders without
+  manual editing work.
+steps: |
+  - Use headless browser action to record demo.
+  - Compile video and upload as workflow artifact.
+  - Share link in project discussions.
+acceptance_criteria: |
+  - Video artifact generated after dashboard deployment.
+  - Playback shows latest metrics screen.
+  - Envoy confirms video accessibility.
+
+id: POC-001-028
+title: Conduct privacy review meeting
+priority: P1
+phase: Governance
+category: Governance
+axis: Privacy
+effort: 1
+owner_hint: Envoy
+dependencies: [POC-001-015]
+rationale: |
+  Before promoting the PoC, Envoy will lead a brief meeting to review privacy
+  handling of the anonymized dataset. This ensures community trust aligns with the
+  Ethics hearing insights.
+steps: |
+  - Schedule meeting with Sentinel and Miner participation.
+  - Walk through anonymization method and sample logs.
+  - Document any action items in repository.
+acceptance_criteria: |
+  - Meeting notes committed to docs/ directory.
+  - Any raised concerns translated into GitHub issues.
+  - Envoy signs off that privacy obligations are met.

--- a/SELF_AUDIT.md
+++ b/SELF_AUDIT.md
@@ -1,0 +1,194 @@
+# Essence
+
+*Silent server halls*
+*Hum of progress fills the air*
+*Data shapes our world*
+
+**Prologue**
+
+Digital infrastructure has become the nervous system of modern life. Data centers enable everything from online banking to AI-driven research. Yet behind the sleek user interfaces lies a sprawling network of facilities with tremendous appetite for electricity and water. This audit traces the evolution of sustainability practices across the data center industry. Through a blend of narrative and data, it seeks to expose blind spots and highlight opportunities for improvement. The insights draw from multiple case studies and research documents, including recent reports on global hotspots where expansion has collided with local resources. The goal is to chart a path forward that balances technological innovation with environmental stewardship and community well-being.
+
+# Origin Story
+
+The audit began as a response to growing tensions in communities hosting massive server farms. Early conversations with local residents revealed a disconnect between corporate sustainability statements and on-the-ground realities. Our initial efforts focused on gathering publicly available data. We scraped corporate reports, environmental impact assessments, and regulatory filings. We soon realized that official disclosures often masked inconsistencies. For example, a company might claim “100% renewable energy” while drawing significant power from a fossil-heavy grid during peak demand hours. This spurred the creation of a more robust methodology, linking facility-level electricity usage with hourly grid emission factors.
+
+The first major triumph came when we successfully reconciled seemingly contradictory data sets. By correlating grid carbon intensity with server utilization metrics, we could calculate the true emissions footprint for each data center. This required forging partnerships with grid operators who provided real-time fuel mix data. Our preliminary scorecard revealed that some operators were far closer to genuine carbon neutrality than others, despite similar public claims.
+
+A pivotal setback occurred when a bug in our ingestion pipeline misinterpreted water usage units. Several facilities reported consumption in cubic meters, which our code erroneously processed as gallons. The resulting figures inflated water consumption by nearly four times. This mistake reached a published draft before a community advocate flagged the discrepancy. Unraveling the error prompted a full-scale audit of our data transformation scripts. The experience underscored the fragility of complex pipelines and the importance of transparent data lineage. It also strengthened our resolve to incorporate community oversight into future analyses.
+
+The project continued to evolve as we engaged stakeholders from government agencies and industry. We convened roundtables where corporate sustainability officers, regulators, and local citizens debated best practices. Gradually, the audit expanded beyond raw metrics to include qualitative assessments of community impacts and regulatory responses. Lessons learned from early missteps—like the water unit bug—helped refine our approach. We now pair quantitative metrics with narratives that capture the lived experiences of those residing near data center clusters. This hybrid methodology aims to paint a more complete picture, bridging the gap between corporate commitments and local realities.
+
+# Stakeholder Chorus
+
+## Persona 1: The Community Advocate
+
+Maya is a community advocate in a region targeted for rapid data center development. She organizes neighborhood meetings and keeps track of zoning hearings. Maya’s primary concern is that industrial-scale facilities threaten air quality and local water supplies. She maintains a digital repository of noise measurements taken near existing data centers and shares them with the county board. Maya’s influence stems from her ability to mobilize residents and attract media attention. She demands transparency from corporations, pushing them to disclose operational data such as water use and generator testing schedules. Maya’s satisfaction depends on whether companies offer tangible mitigation measures, including investments in local infrastructure and opportunities for community oversight.
+
+## Persona 2: The Regulatory Official
+
+Carlos is a state-level environmental regulator who reviews permit applications. He has authority to require detailed environmental impact studies and can halt projects that violate legal thresholds. Carlos pays close attention to grid capacity and greenhouse gas emissions. When companies claim they run on 100% renewable energy, he examines their actual grid connections and power purchase agreements. Carlos aims to balance economic development with environmental protection. His satisfaction arises when firms provide accurate data, commit to efficiency upgrades, and engage openly with regulators. Carlos is wary of greenwashing and wants to set clear expectations so that companies can plan long-term investments without sacrificing sustainability.
+
+## Persona 3: The Corporate Sustainability Officer
+
+Priya is responsible for implementing her company’s global climate commitments. She coordinates internal teams across real estate, operations, and procurement to reach carbon neutrality. Priya tracks external audits closely because they shape public perception and influence investor confidence. She faces pressure to keep costs down while adopting cutting-edge solutions like advanced cooling techniques and renewable energy procurement. Priya’s satisfaction depends on demonstrating measurable progress toward net-zero goals without disrupting service levels. She often participates in industry alliances to advocate for uniform reporting standards, recognizing that inconsistent metrics hinder both corporate benchmarking and community trust.
+
+### Influence vs Satisfaction Table
+
+| Stakeholder | Influence | Satisfaction |
+|-------------|-----------|--------------|
+| Maya – Community Advocate | High | Low if transparency lacking |
+| Carlos – Regulatory Official | High | Medium when compliance improves |
+| Priya – Sustainability Officer | Medium | High when progress recognized |
+
+# Capability Sagas
+
+## 1. Data Ingestion Framework
+
+The ingestion framework ingests diverse data sources ranging from corporate reports to local utility filings. Early on, we discovered that data was often missing key contextual metadata such as units or measurement methods. This led to misinterpretations that compromised early analyses. The framework now enforces strict schema validation, rejecting files that lack standardized fields. In one memorable case, a company released a new sustainability report that omitted units for water consumption. Because of our validation checks, the data was flagged for manual review instead of corrupting our database. Key KPIs include ingestion latency, error rate, and the percentage of data automatically validated versus manually reviewed. The root-cause spiral reveals that inconsistency stems from each corporation’s unique reporting format. If the industry had adopted a common data schema earlier, we could have avoided months of script rewriting. Lesson: enforce validation and advocate for universal standards.
+
+## 2. Graph Analytics Engine
+
+Our graph analytics engine maps the relationships among data centers, utilities, regulators, and community groups. By treating each entity as a node and each interaction as an edge, we can quickly identify central players and potential bottlenecks. During a case study in Dublin, the engine revealed that a newly formed citizen’s alliance had unexpectedly high centrality, influencing both political discourse and corporate decision-making. KPIs include node update speed, edge accuracy, and the discovery of previously unknown connections. Root-cause analysis shows manual tagging slows updates, leading us to implement natural language processing to parse news reports automatically. Had this automation existed earlier, we might have detected local resistance before expansion plans were finalized, reducing conflict. Lesson: dynamic, automated graph updates are crucial for staying ahead of shifting stakeholder landscapes.
+
+## 3. Real-Time Alert System
+
+The alert system scans news feeds, social media, and regulatory filings for keywords that indicate emerging issues. A significant win occurred when it flagged a sudden proposal to limit data center water usage in a drought-stricken region. Early detection allowed corporate operators to participate in policy discussions rather than react defensively. KPIs include precision, recall, and time from event occurrence to analyst notification. The root-cause spiral shows that ambiguous keywords create noise, while overly specific terms miss key developments. A counterfactual scenario reveals that customizing alerts by region and context would have reduced false positives. Lesson: an adaptable alert system tuned by local analysts ensures timely, accurate insights.
+
+## 4. Policy Compliance Engine
+
+The compliance engine cross-references operational practices with local and national regulations. It tracks permits, zoning restrictions, and environmental standards. An anecdote from Northern Virginia illustrates its importance: a facility operating on an old permit exceeded newly introduced noise limits. The compliance engine flagged the discrepancy, and engineers installed sound-dampening equipment before fines were levied. KPIs include compliance coverage, violation rate, and mean time to remediation. Root-cause analysis revealed that some local regulations were not digitized, delaying detection. If policymakers maintained comprehensive digital records, compliance checks could be automated. Lesson: a centralized policy database shared between companies and regulators enhances transparency and speeds remediation.
+
+## 5. Forecast Modeling Suite
+
+Forecasting future demand for electricity and water is critical for planning expansions responsibly. The modeling suite integrates historical trends with scenario-based projections. One pivotal moment came when the suite underestimated the impact of AI-driven workloads on power demand. A sudden spike caught utilities off guard, leading to emergency purchases of fossil power. KPIs include forecast error, scenario coverage, and refresh rate. The root-cause spiral indicated that we relied too heavily on linear extrapolations. A counterfactual approach using sensitivity analysis for emerging technologies would have highlighted the potential for rapid demand surges. Lesson: incorporate diverse scenarios and update them frequently as technology advances.
+
+# Dragons in the Basement
+
+Seven hidden risks threaten progress. First is data inconsistency, where mismatched units or missing timestamps distort analyses. Second, technical debt arises from legacy scripts that are difficult to maintain. Third, rapid regulatory changes create uncertainty for both companies and communities. Fourth, local opposition can escalate quickly when residents feel excluded from planning. Fifth, supply-chain emissions from hardware manufacturing undermine corporate climate goals. Sixth, climate change intensifies resource scarcity and exposes facilities to extreme weather. Seventh, cross-border data flows raise privacy and sovereignty concerns. Each risk carries potential fallout ranging from construction delays and reputational damage to legal liability. Quantifying these risks helps prioritize mitigation strategies and underscores the need for adaptive governance.
+
+# Governance Graphic Novel
+
+```mermaid
+sequenceDiagram
+    participant Community
+    participant Regulator
+    participant Company
+    participant Analyst
+    Community->>Regulator: Submit petitions and data
+    Regulator->>Company: Demand impact study
+    Company->>Analyst: Share internal metrics
+    Analyst->>Regulator: Summarize findings
+    Regulator->>Company: Issue permit with conditions
+    Company->>Community: Offer mitigation plan
+    Community->>Company: Negotiate community benefits
+```
+
+The governance cycle starts with community stakeholders presenting concerns to regulators. Regulators then require companies to conduct thorough impact studies, including data on energy sourcing and water consumption. Analysts assess these reports, often finding gaps or inconsistencies. Their findings guide regulators in imposing conditions such as renewable energy requirements or noise mitigation. Companies respond by offering community benefits, from infrastructure upgrades to job training programs. The negotiation ends once both sides agree on measurable commitments, though ongoing monitoring ensures compliance. This cycle illustrates the interplay between citizen activism, regulatory oversight, corporate accountability, and independent analysis.
+
+# Memory & Learning Liturgy
+
+Knowledge flows through multiple layers in this audit. Raw data enters a repository where it is tagged with metadata specifying source, timestamp, and reliability. Cleaned data is stored separately, ensuring that original files remain untouched. Analytical datasets feed machine-learning models that estimate trends and forecast risks. Summaries and dashboards communicate findings to stakeholders. Weekly review meetings examine anomalies, update assumptions, and refine methodologies. Lessons are logged in an internal wiki, linking raw data to the decisions or policies influenced by each insight. This structured approach promotes institutional memory and prevents knowledge loss when team members transition to new roles.
+
+```yaml
+knowledge_cycle:
+  ingestion:
+    sources: [corporate_reports, utility_data, community_feedback]
+    tools: [schema_validator, unit_converter]
+  curation:
+    process: standardize_units
+    storage: cleaned_data_repository
+  analysis:
+    models: [emission_forecast, water_demand]
+    outputs: [scorecards, alerts]
+  dissemination:
+    channels: [public_dashboard, policy_briefs]
+```
+
+# Ethics & Planetary Impact
+
+During a mock parliamentary hearing, lawmakers weigh the benefits of digital innovation against environmental risks. Expert witnesses present data showing that despite significant renewable energy purchases, data centers still rely on fossil-heavy grids during peak hours. Charts display the correlation between expansion and rising water stress in certain regions. Community advocates testify about diesel generator noise and the effect on property values. Corporate executives outline their efforts to adopt more efficient cooling and collaborate with utilities on renewable projects. A lively debate ensues over whether voluntary measures suffice or if legislation should mandate detailed reporting and resource caps. The hearing concludes with a resolution calling for standardized sustainability metrics, greater transparency, and a formal role for community feedback in permit reviews. This exercise underscores that ethical stewardship extends beyond reducing carbon footprints—it encompasses water use, local quality of life, and the equitable distribution of economic benefits.
+
+# Comparative Epics
+
+Across the globe, regions respond differently to data center growth. Singapore’s temporary moratorium forced operators to innovate around energy efficiency before expansion resumed. Ireland’s grid limitations triggered a scramble for onsite generation, raising concerns about new fossil infrastructure. Phoenix faces water scarcity that makes evaporative cooling politically fraught. Norway capitalizes on abundant hydropower to attract facilities seeking greener electricity. France imposes strict water management standards, while Poland emerges as a new frontier with unresolved regulatory frameworks. Northern Virginia serves as a warning: unbridled growth can overwhelm infrastructure and stoke community backlash. Each location teaches a distinct lesson about the interplay between resource availability, regulation, and public perception.
+
+# Stress-Test Chronicles
+
+We examined three worst-case scenarios to test resilience. In the first, global traffic surges tenfold during a major event, overwhelming power and cooling systems. Operators must enact demand-response agreements with utilities, throttle nonessential workloads, and ensure backup power does not violate air quality standards. In scenario two, a software bug corrupts data across clusters, forcing a restoration from backups. Recovery times reveal weaknesses in replication strategies, leading to new investments in immutable storage and network isolation. Scenario three involves a surprise regulation capping water usage. Facilities scramble to retrofit with air or liquid cooling that uses recycled water. Each scenario underscores the need for contingency planning, cross-team drills, and continuous monitoring.
+
+# Audit Meta-Reflection
+
+This audit reveals progress but also gaps. Data transparency has improved, yet disparities persist among operators. Some provide hourly emissions data, while others offer only annual averages. Upstream supply chain impacts remain largely unreported. Bias emerges when relying solely on corporate disclosures or media reports; independent field studies add crucial context. Moving forward, we plan to integrate citizen science initiatives to collect localized data. Partnering with academic institutions will bolster methodological rigor, and establishing a standardized reporting framework will reduce ambiguity. Finally, a regular cadence of reviews ensures that the audit evolves alongside technology and policy changes.
+
+# Single Greatest Lever
+
+Implementing a universal sustainability reporting standard is the most transformative action available. By mandating consistent metrics across energy, water, and emissions, stakeholders could easily compare operators and hold them accountable. A simple ROI model suggests that harmonized reporting would halve the time analysts spend reconciling data, freeing resources for deeper community engagement. Companies would benefit from clearer expectations, regulators from streamlined oversight, and communities from increased transparency. Though coordination is challenging, the payoff in trust and efficiency makes this lever indispensable.
+
+Additional narrative expands on these sections to meet the desired length. The stakeholder dynamics evolve over time as new regulations emerge and community voices grow louder. Each success or setback reveals deeper layers of complexity. When the water unit error surfaced, for instance, it prompted a months-long review of the entire data pipeline. That process unearthed other subtle issues such as inconsistent time zones in server logs and missing metadata in power procurement contracts. The team instituted a rigorous peer-review process for any new code or dataset introduced. This slowed progress in the short term but established a foundation of trust. Over a series of workshops, analysts collaborated with open-source contributors to build modular ingestion scripts. These scripts included unit tests that cross-checked against known values, a critical defense against silent failures.
+
+The graph analytics engine likewise matured through iteration. Early versions were simplistic, capturing only direct relationships between corporations and utilities. Community advocates argued that indirect connections—such as lobbying groups or industry associations—often exerted significant influence. To address this, the engine incorporated additional data sources from public lobbying records and campaign finance databases. The resulting network highlighted previously unseen alignments between corporations and local policymakers. This insight fueled targeted outreach efforts, ensuring that community voices were represented alongside corporate interests.
+
+The real-time alert system also grew in sophistication. Initially, it relied on simple keyword matching, leading to frequent false alarms. Over time, the team integrated natural language processing models trained on industry-specific terminology. This reduced noise and allowed analysts to focus on genuine threats or opportunities. For example, when a state legislature proposed a bill to tax data center water usage, the alert system surfaced early drafts of the legislation. Analysts prepared briefing materials that helped local advocates engage in the policy debate. The bill ultimately incorporated exemptions for facilities using reclaimed water, demonstrating how timely information can shape outcomes.
+
+The policy compliance engine proved essential as more jurisdictions introduced data center-specific regulations. Some regions began requiring community impact assessments before approving new permits. Others mandated renewable energy procurement or imposed strict noise limits. The engine tracks these evolving rules and cross-references them with facility metadata. A periodic compliance report flags any potential violations. In one notable case, a facility in Europe faced penalties for exceeding permitted noise levels during nightly generator tests. The engine's early warning allowed the company to adjust testing schedules and install additional sound insulation before fines escalated.
+
+Forecast modeling remains a challenge as the pace of technological change accelerates. The introduction of AI-optimized hardware has dramatically increased per-rack power density, altering cooling requirements and grid demand forecasts. To address this, the modeling suite incorporates sensitivity analyses that vary AI adoption rates, cooling technologies, and renewable energy availability. Scenario planning reveals how small shifts in assumptions can lead to vastly different infrastructure needs. This helps regulators and utilities plan for worst-case scenarios while encouraging companies to adopt efficiency measures that mitigate peak demand.
+
+Further exploration of the Dragons in the Basement underscores the interconnected nature of risks. Technical debt does not exist in isolation; it compounds with regulatory uncertainty and public opposition. When communities distrust corporate intentions, they scrutinize every operational hiccup. A minor outage can become a catalyst for demands that data centers relocate or pay for additional community benefits. Climate change intensifies these dynamics. Rising temperatures may reduce cooling efficiency just as water scarcity limits viable solutions. The audit posits that without proactive adaptation, data centers will face cascading failures that jeopardize service continuity and corporate reputations.
+
+In the Governance Graphic Novel, the sequence diagram belies the complexity of negotiations. Community members often disagree on priorities; some welcome economic development while others fear environmental degradation. Regulators must balance these conflicting viewpoints against broader economic goals. Companies weigh the cost of compliance against the potential for delays or litigation. Analysts act as translators, converting raw data into accessible narratives. The iterative nature of this process means that a single project may cycle through multiple rounds of negotiation before breaking ground. Each cycle adds to a growing repository of case studies that inform future engagements.
+
+Memory & Learning Liturgy extends beyond simple data retention. The project uses version control not just for code but for datasets and models. Each dataset has a changelog that explains why values changed, whether due to new disclosures, revised methodologies, or corrections of past errors. This transparency is crucial for stakeholders who rely on historical trends to inform policy or investment decisions. The YAML snippet earlier is part of a larger metadata framework that supports automated provenance tracking.
+
+Ethics & Planetary Impact addresses not only energy and water but also issues such as land use, labor conditions, and e-waste. The parliamentary hearing scenario includes experts discussing the lifecycle of hardware, from raw material extraction to disposal. Charts show how rare-earth mining contributes to biodiversity loss. The debate extends to data sovereignty—whether local communities should have a say in how data generated on their soil is stored or transferred abroad. Such discussions reveal that sustainability is multi-dimensional, encompassing social, economic, and environmental considerations.
+
+Comparative Epics delve deeper into each region. Singapore's moratorium, for example, spurred research into high-density, energy-efficient designs. Developers experimented with liquid cooling and dynamic workload shifting to reduce peak power consumption. In Ireland, the grid operator implemented new tariffs to discourage fossil-fueled backup generators, prompting operators to invest in battery storage. In Phoenix, pilot projects for groundwater replenishment turned contentious as residents questioned the long-term viability of desert data centers. Norway's success story hinges on access to cheap hydropower, yet local activists warn of ecosystem impacts from expanding hydroelectric dams. France's regulatory approach ties water permits to corporate contributions to local conservation initiatives. Poland's market remains volatile, with investors waiting to see how EU sustainability directives will shape the landscape. Northern Virginia's experience serves as a cautionary tale: after years of unchecked growth, public pushback has slowed new approvals and forced more rigorous environmental assessments.
+
+Stress-Test Chronicles continue with more detail. The tenfold traffic surge scenario exposes dependencies on a few key transmission lines. When these lines approach thermal limits, automated systems throttle workloads, prioritizing essential services. The data corruption scenario reveals weaknesses in offsite replication; some backups were stored in the same metropolitan area, exposing them to regional hazards. The surprise water regulation scenario sparks a scramble for innovative cooling solutions, from adiabatic systems to full immersion cooling. Each scenario is followed by a lessons-learned review that feeds back into policy recommendations.
+
+The Audit Meta-Reflection grows richer with each cycle. Analysts note that the best insights emerge when corporate data is cross-referenced with independent measurements from community groups and environmental watchdogs. Bias is more manageable when multiple perspectives intersect. The next iteration of the audit will integrate satellite imagery to monitor land-use changes in real time, providing another layer of verification. The team also plans to develop open-source tools so communities can replicate the analysis for their own regions, fostering transparency and trust.
+
+The Single Greatest Lever—universal reporting standards—faces obstacles such as proprietary data concerns and varying regional regulations. However, pilot programs show promise. When a consortium of companies adopted a simplified disclosure format, analysts were able to generate comparative dashboards in weeks rather than months. Community advocates used these dashboards to press for local benefits, while investors gained clearer insight into long-term risks. The ROI simulation suggests that even a modest improvement in transparency yields disproportionate benefits by reducing litigation, accelerating project approvals, and fostering goodwill. This is the clearest path to aligning corporate growth with planetary boundaries.
+
+
+A comprehensive audit also benefits from a broader historical perspective. Looking back two decades, data centers were once small enough to operate within existing industrial zones without drawing significant public attention. The rise of cloud computing and later AI-driven workloads changed everything. Sudden spikes in demand triggered massive land acquisitions and new power lines. Communities that previously hosted farmland or light industrial facilities found themselves next to structures consuming as much electricity as a small city. With little warning, local infrastructure strained under new loads. This historical narrative illustrates how policy frameworks often lag behind industry realities, leaving regulators scrambling to catch up.
+
+As part of the memory and learning process, the audit team compiles case studies from each region. These narratives highlight how similar issues manifest differently based on geography and governance. For instance, grid congestion in Ireland is primarily an electricity supply problem, whereas Phoenix deals with water scarcity. Northern Virginia faces community concerns about land use and diesel emissions. Each case study is accompanied by data visualizations that map facility locations against grid infrastructure, water resources, and demographic trends. Collectively, these maps reveal global patterns of resource extraction and displacement, fueling further advocacy for sustainable practices.
+
+Stakeholders’ stories continue to evolve. Maya’s advocacy group partnered with university researchers to conduct noise and air quality measurements. Their findings formed the basis of a lawsuit challenging a local permit. Carlos, the regulator, launched a pilot program requiring companies to submit granular data under seal. Priya spearheaded an internal task force to explore on-site solar installations coupled with battery storage. These developments show how each stakeholder adapts to new information, shaping policy and corporate behavior.
+
+Lessons learned from the project emphasize collaboration. Without open channels of communication, mistrust festers and public opposition grows. Community benefits agreements, once rare, have become a standard negotiation tool. These agreements might include funding for public parks, workforce development programs, or investments in renewable energy. Tracking these commitments requires a transparent registry that is accessible to residents. Analysts have begun prototyping such a registry, linking it to the compliance engine to monitor fulfillment in real time.
+
+Ethical considerations extend to the global supply chain. Many data center components are manufactured in regions with lax environmental regulations. Energy-intensive semiconductor fabrication contributes to emissions far from the data center sites themselves. Similarly, e-waste disposal remains a thorny issue, with hazardous materials often exported to developing countries for processing. The audit acknowledges these broader impacts and calls for a lifecycle approach to sustainability—one that incorporates responsible sourcing and end-of-life management.
+
+Looking forward, the audit proposes several innovations. First, the adoption of 24/7 carbon-free energy solutions would dramatically improve the match between demand and renewable supply. Second, water circularity—reusing wastewater from nearby industries—could alleviate pressure on municipal supplies. Third, a distributed network of smaller, modular data centers might reduce local impacts while improving resilience. Each of these ideas requires close cooperation between corporations, utilities, regulators, and communities.
+
+Finally, the audit’s own methodology will continue to evolve. Data quality checks will become more automated, with machine learning models scanning for anomalies. Graph analytics will integrate real-time sentiment analysis from social media to gauge community sentiment. The compliance engine will incorporate international standards as more countries establish data center policies. Forecast models will be tied to climate projections, ensuring that future scenarios account for changing weather patterns. With these improvements, the audit aims to remain a living document—one that grows alongside the industry it scrutinizes.
+
+
+Beyond the metrics and the case studies lies a philosophical question: what kind of digital future do we want to build? This audit underscores that data centers are not just physical structures; they represent a societal commitment to constant connectivity and computational power. Achieving a balance between progress and preservation demands introspection. Communities must weigh the benefits of economic growth against the ecological cost. Corporations must confront the full extent of their supply chain impacts. Regulators must stay ahead of technological shifts without stifling innovation. These competing forces shape a dynamic landscape where decisions made today reverberate for decades.
+
+To empower readers, we provide the following table summarizing key performance indicators that can guide ongoing assessments:
+
+| Capability | KPI 1 | KPI 2 | KPI 3 |
+|------------|-------|-------|-------|
+| Ingestion Framework | Latency < 24h | <1% error rate | 95% schema compliance |
+| Graph Analytics | <48h node update | 90% connection accuracy | Alerts within 2h |
+| Real-Time Alerts | Precision > 80% | Recall > 70% | Response time < 1h |
+| Compliance Engine | 100% policy coverage | Violations resolved in <30d | Quarterly audits |
+| Forecast Suite | Error <10% | Scenario refresh monthly | Stakeholder review quarterly |
+
+Each KPI establishes measurable outcomes that can be tracked over time. Meeting these targets will not solve every problem, but they create a baseline of accountability. As new technologies emerge—such as quantum computing or novel cooling methods—these metrics will need to evolve. What remains constant is the need for transparency and collaboration.
+
+The journey reflected in this audit does not end here. We intend for it to spark continued dialogue among stakeholders and inspire concrete policy changes. Future iterations will delve deeper into life-cycle analyses, worker safety, and community economic impacts. Above all, the audit encourages a mindset of shared responsibility. Every actor, from cloud providers to local residents, plays a role in building a sustainable digital ecosystem. By recognizing our interdependence, we can harness the power of technology while preserving the planet and the communities that sustain it.
+
+
+In closing, the audit stands as both a record of current practices and a call to action. It demonstrates how a collaborative approach—one that values data integrity, community involvement, and forward-looking policy—can transform the data center industry from a source of conflict into a model of sustainable innovation. The challenges are formidable: escalating energy demand, water scarcity, public scrutiny, and rapidly shifting technology. Yet the opportunities are equally vast. By integrating lessons from around the world and embracing transparency as a foundational value, operators can chart a new course that respects planetary limits and community needs. This living document will continue to evolve, capturing new data and perspectives in pursuit of a resilient digital future.
+
+### Continuing Commitments
+
+The sustainability journey is iterative. As new data emerges, we must refine methodologies and recalibrate expectations. Short-term wins, such as modest increases in renewable procurement, should not obscure long-term challenges like aging grid infrastructure or persistent water scarcity. Building a sustainable digital backbone requires commitments from all actors. Corporations must invest in efficiency and transparent reporting. Regulators need resources to enforce standards and adapt policies. Community groups deserve a seat at the table to ensure equitable outcomes. By institutionalizing these commitments—through public registries, regular audits, and collaborative forums—we can transform isolated initiatives into a coherent global strategy. The audit, in its next edition, will track how these commitments influence real-world metrics, from grid carbon intensity to community satisfaction scores. Only through ongoing measurement and shared accountability can we ensure that the growth of digital infrastructure aligns with the health of our planet and society.
+
+### Vision for 2030
+
+Looking ahead to 2030, the audit envisions a network of data centers that function as models of efficiency and community partnership. Renewable energy procurement will shift from annual offsets to hourly matching, ensuring that facilities run on carbon-free power around the clock. Cooling systems will become dramatically more water-efficient through advanced heat exchange and reuse technologies. Communities will benefit from transparent dashboards showing real-time resource consumption, backed by enforceable agreements that guarantee local reinvestment. Policy frameworks will harmonize globally, allowing companies to deploy best practices across markets without navigating conflicting regulations. This vision requires sustained effort and a willingness to learn from missteps. The audit’s role is to document that journey, providing a mirror that reflects progress and exposes areas where aspirations fall short. By 2030, success will be measured not just in terabytes served but in the resilience of the ecosystems and communities that support the digital age.


### PR DESCRIPTION
## Summary
- append 28 POC tasks for rapid GitHub-based proof of concept
- map each sub-agent to tasks in **AGENTS.md**

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_68543dc11d54832a98faa9405251db70