### PR TITLE
Add LangGraph architecture blueprint

### DIFF
--- a/LangGraph_Architectural_Blueprint.md
+++ b/LangGraph_Architectural_Blueprint.md
@@ -1,0 +1,152 @@
+Architectural Blueprint for Deploying a Cognitive Agent Team on LangGraph
+
+1.0 Executive Summary
+This report provides a comprehensive architectural analysis and implementation roadmap for deploying the "Toby's Hill Cognitive Agent Team." The proposed system, which outlines a sophisticated multi-agent team to manage a complex 3D-printed construction project, requires a robust, stateful, and highly controllable orchestration framework.[1] After a comparative analysis of leading agentic frameworks, including CrewAI, AutoGen, and LangGraph, this report concludes that LangGraph is the unequivocally superior foundation for this project..[2, 3, 4, 5]
+LangGraph's core philosophy, which models workflows as explicit state machines, aligns perfectly with the project's requirements for dependency management, quality gates, and multi-entity coordination.[6, 7, 4, 8] Unlike conversational or role-based frameworks, LangGraph provides the granular control over state and execution flow necessary to implement the complex logic defined in the project's workstreams and risk management protocols.[9, 6, 3, 4, 5, 10]
+This document translates the conceptual agent roster and workstreams into a concrete LangGraph architecture. It outlines how:
+ * The Shared Context Layer will be implemented as a persistent, typed State object, serving as the single source of truth for the entire system.[11, 12, 13, 14]
+ * The Agent Roster will be mapped to a graph of nodes, with the PM (Strategic Orchestrator) acting as the central routing function (a conditional edge) and specialist agents (FIN, LAW, GIS, etc.) operating as modular, composable nodes or subgraphs.[4, 15, 8, 16, 17, 18, 19, 20, 21, 22, 23]
+ * The Priority Workstreams will be implemented as distinct paths or sub-graphs within the main orchestration graph, triggered by specific events or state changes.[20, 21, 22, 23]
+ * Quality Gates will be implemented using LangGraph's native human-in-the-loop capabilities, allowing for critical review and approval at key project milestones.[24, 25, 26, 27, 28]
+The final section provides a detailed, phased implementation roadmap for the development team, translating the architectural strategy into a series of actionable tasks. This ensures a structured, efficient, and robust deployment of the Toby's Hill Cognitive Agent Team.
+
+2.0 Framework Selection: Why LangGraph is the Optimal Choice
+The success of a multi-agent system depends on selecting a framework whose architectural philosophy aligns with the project's core requirements. The Toby's Hill project is characterized by complex dependencies, the need for auditable decision-making, and the coordination of multiple specialized entities. This necessitates a framework that prioritizes control, state management, and modularity.[1]
+
+2.1 Comparative Analysis
+ * CrewAI: This framework excels at role-based collaboration, where agents with defined roles and goals work together in a crew.[29, 30, 31, 32, 33, 34] Its hierarchical process, where a manager agent delegates tasks, is powerful for structured workflows.[35, 36, 37] However, its state management is primarily implicit, passed via task outputs, which is less suitable for the complex, shared context required by the Toby's Hill project.[38, 39, 5]
+ * AutoGen: Developed by Microsoft, AutoGen is a conversation-centric framework where agents collaborate through dynamic, often emergent, dialogue.[40, 41, 42, 2, 43, 44, 45, 46, 47] While highly flexible, this emergent nature makes it difficult to enforce the deterministic workflows and strict quality gates specified in the project plan. Its strength lies in research and complex problem-solving where the path to a solution is unknown.[48, 3, 4, 49]
+ * LangGraph: As an extension of LangChain, LangGraph is explicitly designed for creating stateful, multi-actor applications by modeling them as graphs.[24, 9, 6, 7, 4, 8, 50, 10] Its core features are a perfect match for the Toby's Hill project's needs:
+   * Explicit State Management: LangGraph workflows are built around a central, persistent state object. This directly maps to the project's "Shared Context Layer," ensuring all agents have a consistent, up-to-date view of the project's status.[11, 12, 13, 14]
+   * Controllable Workflows: The use of nodes and conditional edges gives developers fine-grained control over the execution path. This is essential for implementing the defined workstreams and dependency chains.[51, 7, 4, 16, 17, 18, 19]
+   * Modularity and Reusability: Agents and workstreams can be encapsulated as nodes or sub-graphs, promoting a clean, modular architecture that is easy to develop, test, and maintain.[15, 20, 21, 22, 23]
+   * Persistence and Human-in-the-Loop: LangGraph's built-in Checkpointer functionality allows workflows to be paused, inspected, and resumed. This is the technical foundation for implementing the project's "Quality Gates" and enabling human oversight and approval.[24, 25, 26, 27, 28, 52, 53, 54, 55]
+
+2.2 Strategic Verdict
+For a project of this complexity and scale, which requires auditable, deterministic, and stateful orchestration, LangGraph is the superior architectural choice. It provides the necessary control and structure to translate the sophisticated cognitive agent team concept into a reliable, production-grade system.
+
+3.0 Architectural Blueprint: Implementing the Cognitive Team in LangGraph
+This section outlines how the conceptual components of the Toby's Hill project will be mapped to the technical primitives of LangGraph.
+
+3.1 The ProjectState Object
+The "Shared Context Layer" will be implemented as a single, comprehensive TypedDict class. This ProjectState will be the central nervous system of the application, passed to every node in the graph.
+
+```python
+from typing import TypedDict, List, Dict, Optional
+from langchain_core.messages import BaseMessage
+
+# Using Annotated and add_messages for append-only message history
+from typing import Annotated
+from langgraph.graph.message import add_messages
+
+class EntityState(TypedDict):
+    name: str
+    status: str
+    budget_allocated: float
+    budget_spent: float
+    risks: List[str]
+
+class ProjectState(TypedDict):
+    # Core workflow state
+    messages: Annotated[list, add_messages]
+    current_workstream: str
+    active_agent: str
+    task_queue: List
+
+    # Shared Context Layer
+    regional_constraints: Dict
+    financial_assumptions: Dict
+    legal_framework: Dict
+    temporal_roadmap: Dict
+
+    # Entity-specific states
+    landhold_co: EntityState
+    build_co: EntityState
+    printer_co: EntityState
+
+    # Deliverables
+    master_plan: Optional[str]
+    financial_model: Optional
+    compliance_report: Optional[str]
+```
+
+3.2 Agent and Workstream Implementation
+ * Agent Roster as Nodes: Each agent in the roster (e.g., RES, FIN, LAW) will be implemented as a node in the LangGraph StateGraph. A node is a Python function that takes the ProjectState as input and returns a dictionary of updates to that state.[51, 7]
+ * PM as the Central Router: The PM (Strategic Orchestrator) agent's logic will be implemented as the graph's primary conditional edge. This router function will inspect the ProjectState (e.g., current_workstream, active_agent, task status) and return the name of the next node to call, effectively directing the flow of work across the agent team.[51, 4, 16, 17, 18, 19]
+ * Workstreams as Sub-Graphs: Complex, multi-step workstreams like "Modular Construction System Design" will be encapsulated as their own StateGraph instances (sub-graphs). The main orchestrator graph will call these sub-graphs as single nodes, promoting modularity and making the overall architecture easier to manage and test.[15, 20, 21, 22, 23]
+ * Tools and Integrations: External data sources and analysis tools (GIS, financial models, etc.) will be implemented as standard LangChain tools. These tools will be made available to the relevant agent nodes, allowing them to interact with external systems to gather information and perform actions.[56, 57, 58, 1, 59]
+
+3.3 Quality Gates and Human-in-the-Loop
+The project's "Quality Gates" will be implemented using LangGraph's native interrupt functionality. At key decision points (e.g., concept validation, financial viability confirmation), the graph will be configured to pause execution and wait for human input.
+
+```python
+from langgraph.graph import END
+from langgraph.checkpoint.sqlite import SqliteSaver
+
+#... (graph definition)...
+
+def quality_gate_node(state: ProjectState):
+    # The graph pauses here, waiting for external input
+    interrupt = True
+    while interrupt:
+        # In a real app, this would be a UI interaction
+        feedback = input("Approve concept? (yes/no): ")
+        if feedback.lower() == "yes":
+            interrupt = False
+        else:
+            # Logic to handle rejection, e.g., route to a revision loop
+            print("Concept rejected. Routing for revision.")
+            # This could return a specific state update to trigger a different path
+            return {"current_workstream": "revision_required"}
+    return state
+
+# In the graph definition
+workflow.add_node("quality_gate_1", quality_gate_node)
+
+# An edge leading to the quality gate
+workflow.add_edge("concept_design_node", "quality_gate_1")
+
+# A conditional edge after the quality gate
+def after_quality_gate(state: ProjectState):
+    if state.get("current_workstream") == "revision_required":
+        return "concept_design_node" # Loop back
+    else:
+        return "financial_viability_node" # Proceed
+
+workflow.add_conditional_edges("quality_gate_1", after_quality_gate)
+```
+
+This pattern ensures that the system combines autonomous execution with critical human oversight, meeting the requirements of the execution framework.
+
+4.0 Implementation Roadmap: A Phased Approach
+The following roadmap provides a structured, phased approach for the development team to build and deploy the Toby's Hill Cognitive Agent Team.
+
+**Phase 1: Core Foundation (Weeks 1-4)**
+Objective: Establish a functional, reactive system that can process documents, route basic tasks, and persist its state.
+ * TICKET: INFRA-001: LangGraph Core Orchestration Engine Setup: Implement the base StateGraph architecture. Define the initial ProjectState TypedDict. Set up state persistence using a SqliteSaver checkpointer to ensure workflows are resumable.[52, 53, 54, 55]
+ * TICKET: INFRA-002: Document Intelligence Pipeline: Build the file processing pipeline for the _intake/ directory. Use a file system watcher (e.g., Python's watchdog) to trigger the workflow.[60, 61, 62, 63] Implement an initial LLM-based content analysis service for semantic routing.[64, 65, 66, 67]
+ * TICKET: AGENT-006: Entity Agent Blueprints: Create the skeleton LangGraph nodes for each lead entity agent (LandHoldCo, BuildCo, PrinterCo). These nodes will serve as the containers for each agent's specific logic and tools.[4, 15, 8]
+ * TICKET: INT-021 & INT-022: Task & Communication Adapters: Build the API connectors to the project's chosen task management (e.g., Linear) and communication (e.g., Slack) platforms.
+ * TICKET: GRD-018: PII Redaction Service: Implement a guardrail node that automatically scans and redacts Personally Identifiable Information (PII) from incoming documents.[1]
+ * TICKET: CORE-015: Predictive Task Generation Service: Implement the basic service that listens for trigger files and initiates the corresponding LangGraph workflow.
+
+**Phase 2: Predictive Intelligence & Workflow Configuration (Weeks 5-8)**
+Objective: Infuse the system with proactive intelligence, enabling it to anticipate needs, manage complex dependencies, and adapt to contextual changes.
+ * TICKET: PRED-003: Phase Transition Automator: Program the Orchestrator router node with the phase_anticipation logic to monitor project milestones and automatically trigger the next phase of tasks.[1]
+ * TICKET: PRED-004: Dependency Chaining Engine: Implement the cascading_triggers system within the Orchestrator router, enabling event-driven scheduling of task sequences.[1]
+ * TICKET: PRED-005: Seasonal Intelligence Service: Integrate external calendar data to allow the Orchestrator to optimize the timing of specific tasks, such as planning submissions or construction activities.[1]
+ * TICKET: SAFE-009: Context-Aware Routing Adjuster: Implement the financial_health and regulatory_risk guardrails. The Orchestrator must check these state variables and dynamically alter its routing logic accordingly.[1]
+ * TICKET: AGENT-007 & AGENT-008: Advanced Agent Collaboration: Implement the "Manager" pattern as a supervisor node that can delegate tasks to multiple specialist agents in parallel and aggregate their results. Implement a controlled handoff protocol between agents.[4, 15, 8]
+ * TICKET: ADV-024, ADV-025, ADV-26: Advanced Intelligence Modules: Begin development of the more advanced predictive models, including the Risk Correlation Analyzer, Cash Flow Optimizer, and the specialized 3DCP Failure Predictor.
+
+**Phase 3: Optimization & Production Hardening (Weeks 9-12)**
+Objective: Finalize the system for live deployment by focusing on self-improvement, monitoring, and comprehensive safety and documentation.
+ * TICKET: OPS-013: Learning Optimization Engine: Implement the routing_effectiveness metrics. The system will track its own performance to identify inefficiencies, creating a feedback loop for continuous improvement.[1]
+ * TICKET: OPS-014: Agent Performance Dashboard: Build a real-time monitoring dashboard (e.g., using Retool or Streamlit) to visualize the KPIs defined in OPS-013.
+ * TICKET: SAFE-010 & GRD-019/020: Advanced Guardrails: Implement the Tool Risk Classifier, which will enforce human-in-the-loop approval for high-risk tool usage. Build out the remaining safety interceptors for relevance and prompt injection.[1]
+ * TICKET: QA-029: Orchestration Simulation Environment: Create a dedicated testing environment to simulate complex, long-running project scenarios, allowing for rigorous testing of the predictive engine and guardrails before deployment.
+ * TICKET: OPS-027, OPS-028, OPS-031: Deployment & Ops: Finalize the Git-based configuration management, build the A/B testing framework for comparing different workflow strategies, and implement the final human escalation protocols.
+ * TICKET: DOC-032: System Blueprint Documentation: Create comprehensive documentation, including Architecture Decision Records (ADRs), to ensure the system is maintainable and extensible.
+
+This structured roadmap provides an efficient and logical path to building the sophisticated, self-orchestrating intelligence system you've envisioned, leveraging the robust, state-centric power of LangGraph as its foundation.
+


### PR DESCRIPTION
## Summary
- add an architectural blueprint describing how to deploy a cognitive agent team on LangGraph

## Testing
- `python -m py_compile task_helper.py`


------
https://chatgpt.com/codex/tasks/task_e_68560fc8b9e4832a9b6abb5b1ec719d1