### PR TITLE
Fix optional type in blueprint

### DIFF
--- a/LangGraph_Architectural_Blueprint.md
+++ b/LangGraph_Architectural_Blueprint.md
@@ -66,7 +66,7 @@ class ProjectState(TypedDict):
 
     # Deliverables
     master_plan: Optional[str]
-    financial_model: Optional
+    financial_model: Optional[str]
     compliance_report: Optional[str]
 ```
 


### PR DESCRIPTION
## Summary
- fix `financial_model` field type in LangGraph blueprint

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_6858b3ba3624832aaceb8217a84a3770