### PR TITLE
Add LangGraph starter graph

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,3 +7,16 @@ Key design references include the architectural blueprint and several research p
 ## License
 
 This project is released under the [MIT License](LICENSE).
+
+## Starter Graph
+
+A minimal LangGraph demo lives in `orchestrator/starter_graph.py`. It shows how
+state is saved with `SqliteSaver` and how a run can resume after interruption.
+Run it with:
+
+```bash
+python -m orchestrator.starter_graph
+```
+
+The first execution processes the ingest node then stops. Running the command
+again resumes from the saved state and completes the analysis step.

--- a/orchestrator/starter_graph.py
+++ b/orchestrator/starter_graph.py
@@ -1,0 +1,80 @@
+from __future__ import annotations
+
+from typing import Dict
+
+from langgraph.graph import StateGraph, END
+from langgraph.checkpoint.sqlite import SqliteSaver
+import sqlite3
+
+from .state import ProjectState
+
+
+# --- Node Definitions -----------------------------------------------------
+
+def ingest(state: ProjectState) -> Dict:
+    """Simulate ingesting a document."""
+    doc = state.get("document", "")
+    messages = state.get("messages", [])
+    messages.append(f"INGEST:{doc}")
+    return {"messages": messages}
+
+
+def analyze(state: ProjectState) -> Dict:
+    """Very basic analysis step."""
+    doc = state["messages"][-1].split(":", 1)[1]
+    messages = state["messages"]
+    messages.append(f"ANALYZED:{doc.upper()}")
+    return {"messages": messages}
+
+
+# --- Graph Builder -------------------------------------------------------
+
+def build_graph(path: str = "graph_state.sqlite"):
+    builder = StateGraph(ProjectState)
+    builder.add_node("ingest", ingest)
+    builder.add_node("analyze", analyze)
+    builder.set_entry_point("ingest")
+    builder.add_edge("ingest", "analyze")
+    builder.add_edge("analyze", END)
+    conn = sqlite3.connect(path, check_same_thread=False)
+    checkpointer = SqliteSaver(conn)
+    return builder.compile(checkpointer=checkpointer)
+
+
+def demo_resumable_run(document: str):
+    """Run the graph in two stages to demonstrate persistence."""
+    session_id = "demo"
+    app = build_graph()
+
+    start_state: ProjectState = {
+        "messages": [],
+        "current_workstream": "demo",
+        "active_agent": "ingest",
+        "task_queue": [],
+        "regional_constraints": {},
+        "financial_assumptions": {},
+        "legal_framework": {},
+        "temporal_roadmap": {},
+        "landhold_co": {},
+        "build_co": {},
+        "printer_co": {},
+        "document": document,
+        "master_plan": None,
+        "financial_model": None,
+        "compliance_report": None,
+    }
+
+    # Process first node then exit early.
+    config = {"configurable": {"thread_id": session_id}}
+    stream = app.stream(start_state, config=config)
+    print("First event:", next(stream))
+    stream.close()
+
+    # Resume from persisted state
+    print("Resuming...")
+    for event in app.stream(None, config=config):
+        print("Resumed event:", event)
+
+
+if __name__ == "__main__":
+    demo_resumable_run("hello world")

--- a/orchestrator/state.py
+++ b/orchestrator/state.py
@@ -1,0 +1,34 @@
+from typing import TypedDict, List, Dict, Optional
+
+class EntityState(TypedDict, total=False):
+    name: str
+    status: str
+    budget_allocated: float
+    budget_spent: float
+    risks: List[str]
+
+class ProjectState(TypedDict, total=False):
+    # Core workflow state
+    messages: List[str]
+    current_workstream: str
+    active_agent: str
+    task_queue: List[str]
+
+    # Shared Context Layer
+    regional_constraints: Dict
+    financial_assumptions: Dict
+    legal_framework: Dict
+    temporal_roadmap: Dict
+
+    # Entity-specific states
+    landhold_co: EntityState
+    build_co: EntityState
+    printer_co: EntityState
+
+    # Deliverables
+    master_plan: Optional[str]
+    financial_model: Optional[str]
+    compliance_report: Optional[str]
+
+    # Temporary field for demo document
+    document: str


### PR DESCRIPTION
## Summary
- add `ProjectState` and supporting TypedDict definitions
- create a minimal LangGraph demo that persists state with SqliteSaver
- document how to run the starter graph

## Testing
- `python -m orchestrator.starter_graph`
- `python task_helper.py | head`


------
https://chatgpt.com/codex/tasks/task_e_6858bb21ecc0832a8aa32e177bdbcd3c